### PR TITLE
refactor(istio): rename ingress gateway resource

### DIFF
--- a/iac/modules/eks/controllers/istio/istio.tf
+++ b/iac/modules/eks/controllers/istio/istio.tf
@@ -44,7 +44,7 @@ resource "helm_release" "istiod" {
 }
 
 # Install Istio Ingress Gateway
-resource "helm_release" "istio_ingress" {
+resource "helm_release" "istio_ingress_gateway" {
   name       = "istio-ingress"
   repository = "https://istio-release.storage.googleapis.com/charts"
   chart      = "gateway"


### PR DESCRIPTION
- Rename helm_release resource from istio_ingress to istio_ingress_gateway
- Make resource name more descriptive and consistent with Istio terminology

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed an internal identifier for the Istio Ingress Gateway to improve consistency while keeping external configurations and functionality unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->