### PR TITLE
feat: Add MongoDB StatefulSet with EBS Storage Configuration

### DIFF
--- a/.github/workflows/data-persistence-pipeline.yml
+++ b/.github/workflows/data-persistence-pipeline.yml
@@ -1,0 +1,42 @@
+name: Data Persistence Pipeline
+
+on:
+  push:
+    paths:
+      - 'kube/storage-class.yml'
+      - 'kube/mongodb-statefulset.yml'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy-infrastructure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-role
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-session-name: GitHubActionsSession
+
+      - name: Update kubeconfig
+        run: aws eks update-kubeconfig --name ${{ secrets.EKS_CLUSTER_NAME }}
+
+      - name: Deploy Storage Class
+        run: |
+            kubectl apply -f kube/storage-class.yml
+            kubectl wait --for=condition=Available storageclass/ebs-sc --timeout=60s
+
+      - name: Deploy MongoDB
+        run: |
+          kubectl apply -f kube/mongodb-statefulset.yml
+          kubectl -n dev wait --for=condition=Ready pod/mongodb-0 --timeout=300s
+
+      - name: Verify MongoDB Status
+        run: |
+          kubectl -n dev get pods -l app=mongodb
+          kubectl -n dev get pvc -l app=mongodb

--- a/kube/mongodb-statefulset.yml
+++ b/kube/mongodb-statefulset.yml
@@ -37,11 +37,11 @@ spec:
               key: password
         resources:
           requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
             cpu: 200m
             memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
         livenessProbe:
           exec:
             command:
@@ -51,7 +51,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
-          failureThreshold: 6
+          failureThreshold: 20
         readinessProbe:
           exec:
             command:
@@ -61,7 +61,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 5
-          failureThreshold: 6
+          failureThreshold: 20
   volumeClaimTemplates:
   - metadata:
       name: mongodb-data
@@ -70,7 +70,7 @@ spec:
       storageClassName: ebs-sc
       resources:
         requests:
-          storage: 10Gi
+          storage: 2Gi
 ---
 apiVersion: v1
 kind: Service

--- a/kube/mongodb-statefulset.yml
+++ b/kube/mongodb-statefulset.yml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb
+  namespace: dev
+spec:
+  serviceName: mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+      - name: mongodb
+        image: mongo:6.0
+        ports:
+        - containerPort: 27017
+          name: mongodb
+        volumeMounts:
+        - name: mongodb-data
+          mountPath: /data/db
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secret
+              key: username
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mongodb-secret
+              key: password
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          exec:
+            command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - mongo
+            - --eval
+            - "db.adminCommand('ping')"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+  volumeClaimTemplates:
+  - metadata:
+      name: mongodb-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: ebs-sc
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  namespace: dev
+  labels:
+    app: mongodb
+spec:
+  ports:
+  - port: 27017
+    targetPort: 27017
+  clusterIP: None
+  selector:
+    app: mongodb
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-secret
+  namespace: dev
+type: Opaque
+stringData:
+  username: mongoadmin
+  password: secret123

--- a/kube/persistent-storage.yml
+++ b/kube/persistent-storage.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"
+  iops: "3000"
+  throughput: "125"
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb-pvc
+  namespace: dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 10Gi

--- a/kube/storage-class.yml
+++ b/kube/storage-class.yml
@@ -12,16 +12,3 @@ parameters:
   throughput: "125"
 reclaimPolicy: Delete
 allowVolumeExpansion: true
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mongodb-pvc
-  namespace: dev
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ebs-sc
-  resources:
-    requests:
-      storage: 10Gi

--- a/kube/todo-application-workload.yml
+++ b/kube/todo-application-workload.yml
@@ -34,6 +34,9 @@ spec:
       containers:
       - name: todo-application
         image: ${DOCKER_REGISTRY}/application:${VERSION}
+        volumeMounts:
+        - name: todo-data
+          mountPath: /app/data
         ports:
         - containerPort: 3000
           name: http-port
@@ -74,6 +77,27 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         imagePullPolicy: Always
+      volumes:
+      - name: todo-data
+        persistentVolumeClaim:
+          claimName: todo-app-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: todo-app-pvc
+  namespace: dev
+  labels:
+    app.kubernetes.io/name: todo-application
+    app.kubernetes.io/instance: dev
+    app.kubernetes.io/part-of: todo-application
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 2Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- Add MongoDB StatefulSet deployment with:
  - Headless service for direct pod access
  - Resource limits and health checks
  - Secure credentials using Kubernetes Secret
  - Volume mounts for persistent data

- Configure AWS EBS storage with:
  - Custom StorageClass using EBS CSI driver
  - GP3 volume type with optimized performance (3000 IOPS)
  - Encryption enabled for security
  - WaitForFirstConsumer binding mode
  - Volume expansion support

- Set up PersistentVolumeClaim for MongoDB:
  - 10GB storage allocation
  - ReadWriteOnce access mode
  - Namespace-scoped in dev environment

This implementation ensures reliable and persistent storage for MongoDB using AWS EBS volumes with proper security and performance settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced add-on configuration with additional optional parameters and improved role management.
  - Introduced a stateful database setup featuring secure credential handling, persistent storage, and health monitoring.
  - Added an automated deployment workflow that integrates storage services with database readiness checks.
  - Configured a high-performance storage option and persistent volume for improved application data retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->