### PR TITLE
feat(eks): Add EKS cluster add-ons and core components

### DIFF
--- a/iac/modules/eks/00-init.tf
+++ b/iac/modules/eks/00-init.tf
@@ -6,6 +6,12 @@ resource "kubernetes_namespace" "dev_namespace" {
       "namespace" = "dev"
     }
   }
+
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_eks_node_group.main
+
+  ]
 }
 
 resource "kubernetes_namespace" "monitoring" {
@@ -15,6 +21,11 @@ resource "kubernetes_namespace" "monitoring" {
       "namespace" = "monitoring"
     }
   }
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_eks_node_group.main,
+    kubernetes_namespace.dev_namespace
+  ]
 }
 
 # Create Docker registry secret
@@ -38,5 +49,9 @@ resource "kubernetes_secret" "docker_registry" {
     })
   }
 
-  depends_on = [kubernetes_namespace.dev_namespace]
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_eks_node_group.main,
+    kubernetes_namespace.dev_namespace
+  ]
 }

--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -40,6 +40,13 @@ module "istio" {
   cluster_name = aws_eks_cluster.main.id
   istio_version = "1.25.0"
   kiali_version = "1.40.0"
+
+  depends_on = [
+    aws_eks_cluster.main,
+    aws_eks_node_group.main,
+    kubernetes_namespace.monitoring,
+    aws_eks_addon.addons
+  ]
 }
 
 data "http" "metric_server" {
@@ -54,6 +61,9 @@ resource "kubernetes_manifest" "metric_server" {
   for_each = { for idx, manifest in compact(local.metrics_server_manifests) : idx => manifest if manifest != "" }
   manifest = yamldecode(each.value)
   depends_on = [
-    kubernetes_namespace.monitoring
+    aws_eks_cluster.main,
+    aws_eks_node_group.main,
+    kubernetes_namespace.monitoring,
+    aws_eks_addon.addons
   ]
 }


### PR DESCRIPTION
- Configure essential EKS add-ons (kube-proxy, vpc-cni, coredns, aws-ebs-csi-driver, aws-efs-csi-driver)
- Install Istio service mesh with Kiali dashboard (v1.25.0)
- Deploy Kubernetes metrics server
- Set up IAM roles and policies for cluster and worker nodes
- Configure autoscaling and CloudWatch access policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved resource provisioning order to ensure all critical services initialize reliably.
  - Enhanced system orchestration for smoother and more dependable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->