### PR TITLE
fix(eks): Add wait condition for EKS cluster readiness

### DIFF
--- a/iac/modules/eks/00-init.tf
+++ b/iac/modules/eks/00-init.tf
@@ -1,3 +1,10 @@
+resource "null_resource" "wait_for_eks" {
+  provisioner "local-exec" {
+    command = "until kubectl get ns kube-system; do sleep 10; done"
+  }
+  depends_on = [aws_eks_cluster.main, aws_eks_node_group.main]
+}
+
 # Create dev namespace
 resource "kubernetes_namespace" "dev_namespace" {
   metadata {
@@ -9,8 +16,8 @@ resource "kubernetes_namespace" "dev_namespace" {
 
   depends_on = [
     aws_eks_cluster.main,
-    aws_eks_node_group.main
-
+    aws_eks_node_group.main,
+    null_resource.wait_for_eks
   ]
 }
 
@@ -24,7 +31,7 @@ resource "kubernetes_namespace" "monitoring" {
   depends_on = [
     aws_eks_cluster.main,
     aws_eks_node_group.main,
-    kubernetes_namespace.dev_namespace
+    null_resource.wait_for_eks
   ]
 }
 


### PR DESCRIPTION
- Add null_resource with local-exec provisioner to wait for EKS cluster to be fully operational
- Update namespace dependencies to ensure proper initialization sequence
- Fix dependency chain for dev and monitoring namespaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated process to verify that critical system components are fully operational before deploying related environments.
  - Improved the initialization sequence, ensuring key system namespaces are available only after the core services are confirmed ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->