### PR TITLE
refactor(eks): Streamline EBS CSI driver configuration

### DIFF
--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -66,7 +66,6 @@ locals {
   all_addons = concat(var.addons, [
     {
       name = "aws-ebs-csi-driver"
-      version = "v1.25.0-eksbuild.1"
       service_account_role_arn = aws_iam_role.ebs_csi.arn
       configuration_values = jsonencode({
         controller = {


### PR DESCRIPTION
- Remove duplicate EBS CSI driver entry from default addons list
- Remove hardcoded version constraint for EBS CSI driver
- Keep EBS CSI driver configuration in local addons block only