### PR TITLE
feat(eks): Add dynamic version management for EBS CSI driver

### DIFF
--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -62,10 +62,19 @@ resource "aws_iam_role_policy_attachment" "ebs_csi" {
   role       = aws_iam_role.ebs_csi.name
 }
 
+# Get latest EBS CSI driver version
+data "aws_eks_addon_version" "ebs_csi" {
+  addon_name         = "aws-ebs-csi-driver"
+  kubernetes_version = aws_eks_cluster.main.version
+  most_recent       = true
+}
+
+
 locals {
   all_addons = concat(var.addons, [
     {
       name = "aws-ebs-csi-driver"
+      version = data.aws_eks_addon_version.ebs_csi.version
       service_account_role_arn = aws_iam_role.ebs_csi.arn
       configuration_values = jsonencode({
         controller = {


### PR DESCRIPTION
- Add aws_eks_addon_version data source to fetch latest compatible version
- Replace hardcoded EBS CSI driver version with dynamic version lookup
- Ensure version compatibility with cluster's Kubernetes version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The system now automatically selects the most up-to-date AWS EBS storage driver version based on your EKS cluster's current Kubernetes release, ensuring your cluster consistently benefits from the latest updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->