### PR TITLE
fix(eks): Remove invalid configuration_values from EBS CSI driver addon

### DIFF
--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -76,14 +76,6 @@ locals {
       name = "aws-ebs-csi-driver"
       version = data.aws_eks_addon_version.ebs_csi.version
       service_account_role_arn = aws_iam_role.ebs_csi.arn
-      configuration_values = jsonencode({
-        controller = {
-          serviceAccount = {
-            create = true
-            name   = "ebs-csi-controller-sa"
-          }
-        }
-      })
     }
   ])
 }


### PR DESCRIPTION
- Remove unsupported service account configuration from EBS CSI driver addon
- Rely on IRSA configuration through service_account_role_arn for proper IAM setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the configuration of the EBS CSI driver add-on by removing redundant custom settings. This update ensures that the add-on now relies on default system behavior during provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->