### PR TITLE
refactor(eks): Remove unused configuration_values from addons

### DIFF
--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -3,7 +3,6 @@ variable "addons" {
     name                    = string
     version                 = optional(string)
     service_account_role_arn = optional(string)
-    configuration_values    = optional(string)
   }))
 
   default = [
@@ -86,7 +85,6 @@ resource "aws_eks_addon" "addons" {
   addon_name        = each.value.name
   addon_version     = each.value.version
   service_account_role_arn = each.value.service_account_role_arn
-  configuration_values = each.value.configuration_values
   resolve_conflicts_on_update = "PRESERVE"
   
   depends_on = [


### PR DESCRIPTION
- Remove configuration_values field from addons variable type definition
- Remove configuration_values from aws_eks_addon resource
- Clean up unused configuration options for better code maintainability