### PR TITLE
fix(ci): Revert StatefulSet rollout check to pod readiness check

### DIFF
--- a/.github/workflows/data-persistence-pipeline.yml
+++ b/.github/workflows/data-persistence-pipeline.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Deploy Storage Class
         run: |
             kubectl apply -f kube/storage-class.yml
-            kubectl wait --for=condition=Available storageclass/ebs-sc --timeout=60s
+            kubectl get storageclass/ebs-sc
 
       - name: Deploy MongoDB
         run: |


### PR DESCRIPTION
- Keep original pod readiness check for MongoDB deployment
- Remove incorrect StorageClass condition check
- Simplify StorageClass verification to use get command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the storage deployment process by adjusting how configuration details are fetched, enhancing overall deployment efficiency without impacting visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->