### PR TITLE
fix(ci): Revert StatefulSet rollout check to pod readiness check

### DIFF
--- a/.github/workflows/data-persistence-pipeline.yml
+++ b/.github/workflows/data-persistence-pipeline.yml
@@ -3,8 +3,9 @@ name: Data Persistence Pipeline
 on:
   push:
     paths:
-      - 'kube/storage-class.yml'
-      - 'kube/mongodb-statefulset.yml'
+    - '.github/workflows/data-persistence-pipeline.yml'
+    - 'kube/storage-class.yml'
+    - 'kube/mongodb-statefulset.yml'
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
- Keep original pod readiness check for MongoDB deployment
- Remove incorrect StorageClass condition check
- Simplify StorageClass verification to use get command