### PR TITLE
feat(eks): add IMDS access policy for EBS CSI driver

### DIFF
--- a/iac/modules/eks/main.tf
+++ b/iac/modules/eks/main.tf
@@ -116,6 +116,29 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_full_access" {
     role       = aws_iam_role.node.name
 }
 
+resource "aws_iam_role_policy" "node_imds" {
+  name = "${local.name}-Worker-IMDS-Policy"
+  role = aws_iam_role.node.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node_imds" {
+  policy_arn = aws_iam_role_policy.node_imds.arn
+  role       = aws_iam_role.node.name
+}
+
 # Create instance profile for worker nodes
 resource "aws_iam_instance_profile" "worker_nodes" {
   name = "${local.name}-Worker-Profile"
@@ -183,6 +206,7 @@ resource "aws_eks_node_group" "main" {
     aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_imds
   ]
 
   tags = merge(


### PR DESCRIPTION
- Add IAM policy granting EC2 DescribeInstances permission to worker nodes
- Attach policy to node role to enable IMDS access for EBS CSI driver
- Add dependency in node group to wait for policy attachment

This change enables the EBS CSI driver to access instance metadata required for volume provisioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the configuration of EKS node groups to automatically apply updated policies for improved instance metadata access.
	- Ensured that the new settings are consistently enforced during node provisioning for a more robust and secure operational experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->