### PR TITLE
feat(eks): enhance EBS CSI driver permissions

### DIFF
--- a/iac/modules/eks/main.tf
+++ b/iac/modules/eks/main.tf
@@ -116,29 +116,6 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_full_access" {
     role       = aws_iam_role.node.name
 }
 
-resource "aws_iam_role_policy" "node_imds" {
-  name = "${local.name}-Worker-IMDS-Policy"
-  role = aws_iam_role.node.name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "ec2:DescribeInstances"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "node_imds" {
-  policy_arn = aws_iam_role_policy.node_imds.arn
-  role       = aws_iam_role.node.name
-}
-
 # Create instance profile for worker nodes
 resource "aws_iam_instance_profile" "worker_nodes" {
   name = "${local.name}-Worker-Profile"
@@ -206,7 +183,7 @@ resource "aws_eks_node_group" "main" {
     aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
-    aws_iam_role_policy_attachment.node_imds
+    aws_iam_role_policy.node_imds
   ]
 
   tags = merge(


### PR DESCRIPTION
- Add inline IAM policy with explicit EC2 permissions for volume operations
- Keep existing AWS managed EBS CSI policy for core functionality
- Maintain PRESERVE conflict resolution to avoid disrupting existing configs

This ensures the EBS CSI driver has all required permissions while preserving existing configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an enhanced policy to broaden volume management capabilities for storage components.
  
- **Refactor**
  - Streamlined worker node permission management by eliminating redundant configurations and referencing policies directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->