### PR TITLE
refactor(eks): simplify node group and launch template tags

### DIFF
--- a/iac/modules/eks/main.tf
+++ b/iac/modules/eks/main.tf
@@ -189,8 +189,7 @@ resource "aws_launch_template" "eks_nodes" {
     resource_type = "instance"
     tags = merge(
       {
-        "Name" = "${local.name}-${each.key}",
-        "kubernetes.io/cluster/${aws_eks_cluster.main.name}" = "owned"
+        "Name" = "${local.name}-${each.key}"
       },
       var.tags
     )
@@ -270,11 +269,7 @@ resource "aws_eks_node_group" "main" {
 
   tags = merge(
     {
-      "Name" = "${local.name}-${each.key}",
-      "kubernetes.io/cluster/${aws_eks_cluster.main.name}" = "owned",
-      "k8s.io/cluster-autoscaler/${aws_eks_cluster.main.name}" = "owned",
-      "eks:cluster-name" = aws_eks_cluster.main.name,
-      "aws:eks:cluster-name" = aws_eks_cluster.main.name
+      "Name" = "${local.name}-${each.key}"
     },
     var.tags
   )


### PR DESCRIPTION
- Remove cluster-specific tags from launch template and node group
- Keep only Name tag for better simplicity and maintainability
- Retain var.tags merging for custom tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined resource tagging by removing redundant, auto-generated tags.
  - Retained only the essential "Name" identifier to simplify metadata management without impacting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->