### PR TITLE
chore: temporarily disable EFS CSI driver add-on

### DIFF
--- a/iac/modules/eks/add-ons.tf
+++ b/iac/modules/eks/add-ons.tf
@@ -14,10 +14,10 @@ variable "addons" {
     },
     {
       name    = "coredns"
-    },
-    {
-      name    = "aws-efs-csi-driver"
     }
+    # {
+    #   name    = "aws-efs-csi-driver"
+    # }
   ]
 }
 


### PR DESCRIPTION
- Comment out aws-efs-csi-driver from eks add-ons list
- Keep vpc-cni and coredns add-ons enabled
- Simplify initial cluster setup

This change reduces complexity by focusing on essential add-ons first. EFS CSI driver can be re-enabled later when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default add-on configuration by disabling an optional file storage integration component. This streamlines the set of active components for deployments while preserving the option to re-enable the feature if needed. Core functionalities remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->