### PR TITLE
fix(mongodb): update health probes to use mongosh command

### DIFF
--- a/kube/mongodb-statefulset.yml
+++ b/kube/mongodb-statefulset.yml
@@ -45,7 +45,7 @@ spec:
         livenessProbe:
           exec:
             command:
-            - mongo
+            - mongosh
             - --eval
             - "db.adminCommand('ping')"
           initialDelaySeconds: 30
@@ -55,7 +55,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - mongo
+            - mongosh
             - --eval
             - "db.adminCommand('ping')"
           initialDelaySeconds: 30


### PR DESCRIPTION
- Replace mongo command with mongosh in liveness probe
- Replace mongo command with mongosh in readiness probe
- Fix MongoDB 6.0 health check failures
- Update probes to use current MongoDB shell command

This change updates the MongoDB StatefulSet to use the mongosh command instead of the deprecated mongo command for health checks. MongoDB 6.0 removed the old mongo shell in favor of mongosh, so this fixes the "executable not found" errors in the pod probes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the database container’s health check commands for improved reliability and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->