### PR TITLE
fix(ci): correct MongoDB credential export syntax

### DIFF
--- a/.github/workflows/data-persistence-pipeline.yml
+++ b/.github/workflows/data-persistence-pipeline.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Deploy MongoDB
         run: |
-          export MONGODB_USERNAME= ${{ secrets.MONGODB_USERNAME }}
-          export MONGODB_PASSWORD= ${{ secrets.MONGODB_PASSWORD }}
+          export MONGODB_USERNAME=${{ secrets.MONGODB_USERNAME }}
+          export MONGODB_PASSWORD=${{ secrets.MONGODB_PASSWORD }}
           cat kube/mongodb-statefulset.yml | envsubst | kubectl apply -f -
           kubectl -n dev wait --for=condition=Ready pod/mongodb-0 --timeout=300s
 


### PR DESCRIPTION
- Remove spaces after equals signs in export commands
- Fix invalid shell syntax in environment variable exports
- Ensure proper variable assignment for MongoDB credentials
- Fix pipeline failure in data persistence workflow

This change fixes the shell syntax error in the MongoDB deployment step by removing spaces after equals signs in the export commands, allowing proper environment variable assignment for credential substitution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration to ensure secure settings are applied correctly, enhancing overall system stability and performance without impacting user-visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->